### PR TITLE
feat(Tests.Integration): Reenable server cluster pub-sub tests

### DIFF
--- a/test/Tests.Integration/MimoriaServerClusterTests.PubSub.cs
+++ b/test/Tests.Integration/MimoriaServerClusterTests.PubSub.cs
@@ -8,7 +8,7 @@ namespace Varelen.Mimoria.Tests.Integration;
 
 public partial class MimoriaServerClusterTests : IAsyncLifetime
 {
-    [Fact(Skip = "TODO: Problems in GH action")]
+    [Fact]
     public async Task PubSub_Given_TwoNodes_When_SubscribeAndPublishString_Then_PayloadEventIsCalled()
     {
         // Arrange
@@ -30,7 +30,7 @@ public partial class MimoriaServerClusterTests : IAsyncLifetime
         Assert.Equal("value", value);
     }
 
-    [Fact(Skip = "TODO: Problems in GH action")]
+    [Fact]
     public async Task PubSub_Given_TwoNodes_When_SubscribeAndPublishBytes_Then_PayloadEventIsCalled()
     {
         // Arrange
@@ -52,7 +52,7 @@ public partial class MimoriaServerClusterTests : IAsyncLifetime
         Assert.Equal([1, 2, 3, 4], value);
     }
 
-    [Fact(Skip = "TODO: Problems in GH action")]
+    [Fact]
     public async Task PubSub_Given_TwoNodes_When_SubscribeAndUnsubscribeAndPublish_Then_PayloadEventIsNotCalled()
     {
         // Arrange
@@ -77,7 +77,7 @@ public partial class MimoriaServerClusterTests : IAsyncLifetime
         Assert.Null(value);
     }
 
-    [Fact(Skip = "TODO: Problems in GH action")]
+    [Fact]
     public async Task PubSub_Given_TwoNodes_When_PrimaryGoesDown_Then_NewLeaderIsPublishedInPrimaryChangedChannel()
     {
         // Arrange


### PR DESCRIPTION
Reenable the previous disabled server cluster pub-sub tests to check if there are still problems when running them with GitHub Actions.